### PR TITLE
Add conditional for site cookies

### DIFF
--- a/layout-fetcher.js
+++ b/layout-fetcher.js
@@ -31,14 +31,16 @@ module.exports = function(url, options) {
 
         var requestOptions = {
             url: url,
-
             headers: {
-                // Pass cookies from the client through to the layout service
-                cookie: req.headers.cookie,
-                // Provide the remote IP address to the layout service
-                'X-Forwarded-For': req.connection.remoteAddress
+              // Provide the remote IP address to the layout service
+              'X-Forwarded-For': req.connection.remoteAddress
             }
         };
+
+        if (req.headers.cookie !== undefined) {
+            // Pass cookies from the client through to the layout service
+            requestOptions.headers.cookie = req.headers.cookie;
+        }
 
         request(requestOptions, function (requestError, requestResponse, responseBody) {
             if (requestError || requestResponse.statusCode !== 200) {


### PR DESCRIPTION
If a page has no cookies undefined is passed to the request options causing the app to break:
"Error: "name" and "value" are required for setHeader()."

This branch adds a conditional to stop this behaviour.
